### PR TITLE
Add Docker Compose configuration for MySQL database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.4.5
+    container_name: mysql-db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: mydb
+      MYSQL_USER: dbuser
+      MYSQL_PASSWORD: dbpassword
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./docker/mysql/init:/docker-entrypoint-initdb.d
+    networks:
+      - app-network
+
+volumes:
+  mysql-data:
+    driver: local
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Add Docker Compose configuration with MySQL 8.4.5 LTS
- Configure database credentials and networking
- Set up volume for data persistence

## Test plan
- [ ] Run `docker-compose up -d` to start the MySQL container
- [ ] Verify MySQL container is running with `docker ps`
- [ ] Test database connection with configured credentials

🤖 Generated with [Claude Code](https://claude.ai/code)